### PR TITLE
Use deploy.js instead of deploys.json

### DIFF
--- a/lib/commands/base-command-factory.js
+++ b/lib/commands/base-command-factory.js
@@ -11,7 +11,7 @@ module.exports = function() {
   return {
     getConfigForEnvironment: function(environment) {
       var root = process.cwd();
-      var config = require(path.join(root, 'deploy.json'))[environment];
+      var config = require(path.join(root, 'deploy.js'))[environment];
 
       if (!config) {
         this.ui.writeLine(chalk.red('Config for "' + environment + '" environment not found.\n'));


### PR DESCRIPTION
I don't like having the AWS keys in a static json file. Thoughts on using deploys.js that will export a object? That way we can have logic in there that pulls the keys from a safe place.
