### PR TITLE
change endpoint

### DIFF
--- a/lib/commands/base-command-factory.js
+++ b/lib/commands/base-command-factory.js
@@ -11,7 +11,7 @@ module.exports = function() {
   return {
     getConfigForEnvironment: function(environment) {
       var root = process.cwd();
-      var config = require(path.join(root, 'deploy.json'))[environment];
+      var config = require(path.join(root, 'deploy.js'))[environment];
 
       if (!config) {
         this.ui.writeLine(chalk.red('Config for "' + environment + '" environment not found.\n'));

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -74,7 +74,11 @@ module.exports = Task.extend({
   run: function(environment, config, verbose) {
     var _this = this;
     var promises = [];
-    var endpoints = config.index.endpoints;
+    var endpoints = config.index.endpoints.map(function(endpoint) {
+          return (endpoint.match(/\/front_end_builds\/builds$/) ?
+                  endpoint :
+                  endpoint + '/front_end_builds/builds');
+        });
 
     endpoints.forEach(function(endpoint) {
       promises.push(_this.notifyEndpoint(endpoint, config, verbose));


### PR DESCRIPTION
It's always POST to /front_end_builds/builds, so make it so deploy.json can be just

```
http://ed.ted.com
```

instead of

```
http://ed.ted.com/front_end_builds/builds
```
