### PR TITLE
Load env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,23 @@ You'll also need to setup a S3 bucket, and allow it to be accessed publicly.  Ad
 
 #### Ember App Setup
 
-In your App's `Brocfile.js`, you'll want to prepend your asset fingerprinting with your S3 Bucket URL:
+In your App's `ember-cli-build.js`, you'll want to prepend your asset fingerprinting with your S3 Bucket URL:
 
 ```js
+var env = process.env.EMBER_ENV;
+var fingerprintOptions = {
+  enabled: true
+};
+switch (env) {
+  case 'development':
+    fingerprintOptions.prepend = 'http://localhost:4200/';
+  break;
+  case 'production':
+    fingerprintOptions.prepend = 'https://s3.amazonaws.com/MY-BUCKET-NAME/dist/';
+  break;
+}
 var app = new EmberApp({
-  'fingerprint': {
-    prepend: "https://s3.amazonaws.com/MY-BUCKET-NAME/dist/"
-  }
+  'fingerprint': fingerprintOptions
 });
 ```
 
@@ -76,8 +86,8 @@ TODO
 {
   "production": {
     "assets": {
-      "accessKeyId": "[your-id]",
-      "secretAccessKey": "[your-key]",
+      "accessKeyId": process.env.ACCESS_KEY_ID,
+      "secretAccessKey": process.env.SECRET_ACCESS_KEY,
       "bucket": "[your-s3-bucket]",
       "prefix": "[optional, dir on S3 to dump all assets]",
       "distPrefix": "[optional, dir on S3 to put `dist` in e.g. dist-{{SHA}}]"
@@ -93,6 +103,19 @@ TODO
     }
   }
 }
+```
+
+### Add .env file in root dir of project
+
+```
+ACCESS_KEY_ID=YOUR-ACCESS-KEY
+SECRET_ACCESS_KEY=YOUR-SECRET-KEY
+```
+
+### Edit `.gitignore`
+
+```
+/.env
 ```
 
 ## Usage

--- a/lib/commands/base-command-factory.js
+++ b/lib/commands/base-command-factory.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var chalk = require('chalk');
 
+require('dotenv').load();
 // Tried just exporting an object, but it was getting
 // mutated by each function that was _.extend'ing it.
 // I'm sure there's a way to export a POJO and not have

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "s3": "^4.3.1",
     "sync-exec": "^0.4.0",
     "underscore": "^1.7.0",
-    "silent-error": "^1.0.0"
+    "silent-error": "^1.0.0",
+    "dotenv": "^1.2.0"
   }
 }


### PR DESCRIPTION
With this pull request, we can checkin deploy.js to public repository.

Store secret keys in `.env` file and use `process.env.KEY` to access keys
